### PR TITLE
remove malware URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-/*  http://bblck.me/:splat 200

--- a/blocklists/adblock-plus.txt
+++ b/blocklists/adblock-plus.txt
@@ -3,7 +3,7 @@
 ! Title: BarbBlock
 ! Last modified: 2019-05-26
 ! Expires: 1 days
-! Homepage: https://ssl.bblck.me/
+! Homepage: https://paulgb.github.io/BarbBlock/
 ! ============== Site group 1 ==============
 ! GitHub Issue: https://github.com/paulgb/BarbBlock/issues/1
 ! Takedown URL: https://github.com/github/dmca/blob/master/2017/2017-08-02-LevenLabs.md

--- a/blocklists/hosts-file.txt
+++ b/blocklists/hosts-file.txt
@@ -1,8 +1,8 @@
 # BarbBlock
 # Version: 1.5
 # Last Update: 2019-05-26
-# Homepage: https://ssl.bblck.me/
-# Canonical URL for this file: https://ssl.bblck.me/blacklists/hosts-file.txt
+# Homepage: https://paulgb.github.io/BarbBlock/
+# Canonical URL for this file: https://paulgb.github.io/BarbBlock/blacklists/hosts-file.txt
 
 # ============== Site group 1 ==============
 # GitHub Issue: https://github.com/paulgb/BarbBlock/issues/1

--- a/blocklists/ublock-origin.txt
+++ b/blocklists/ublock-origin.txt
@@ -1,6 +1,6 @@
 ! Title: BarbBlock
-! Homepage: https://ssl.bblck.me/
-! Redirect: https://ssl.bblck.me/blacklists/ublock-origin.txt
+! Homepage: https://paulgb.github.io/BarbBlock/
+! Redirect: https://paulgb.github.io/BarbBlock/blacklists/ublock-origin.txt
 ! Blocks requests to sites which have used legal threats to remove themselves from other blacklists.
 ! ============== Site group 1 ==============
 ! GitHub Issue: https://github.com/paulgb/BarbBlock/issues/1

--- a/install.md
+++ b/install.md
@@ -1,11 +1,11 @@
 # Install BarbBlock
 
-For Chrome and Firefox extensions, see the [main page](https://ssl.bblck.me/).
+For Chrome and Firefox extensions, see the [main page](https://paulgb.github.io/BarbBlock/).
 
 ## Ublock Origin
 
-[Click this link to subscribe](abp:subscribe?location=https://ssl.bblck.me/blacklists/ublock-origin.txt&title=BarbBlock)	[Click this link to subscribe](ubo:subscribe?location=https://paulgb.github.io/BarbBlock/blacklists/ublock-origin.txt&title=BarbBlock)
+[Click this link to subscribe](ubo:subscribe?location=https://paulgb.github.io/BarbBlock/blacklists/ublock-origin.txt&title=BarbBlock)
 
-## Adblock Plus	## Adblock Plus
+## Adblock Plus
 
-[Click this link to subscribe](abp:subscribe?location=https://ssl.bblck.me/blacklists/adblock-plus.txt&title=BarbBlock)	[Click this link to subscribe](abp:subscribe?location=https://paulgb.github.io/BarbBlock/blacklists/adblock-plus.txt&title=BarbBlock)
+[Click this link to subscribe](abp:subscribe?location=https://paulgb.github.io/BarbBlock/blacklists/adblock-plus.txt&title=BarbBlock)


### PR DESCRIPTION
There are still several links to the domain that got turned into malware (ssl.bblck.me) that were accidentally left, so this commit removes all traces of that site except for the note saying to update your URLs