### PR TITLE
Dedupe "smilingwaves.com"

### DIFF
--- a/blacklist.yaml
+++ b/blacklist.yaml
@@ -531,7 +531,6 @@ blacklist:
   - slipperysack.com
   - smashsurprise.com
   - smilingwaves.com
-  - smilingwaves.com
   - snakesort.com
   - sombersea.com
   - sombersquirrel.com


### PR DESCRIPTION
Dedupe "smilingwaves.com" as per <https://github.com/paulgb/BarbBlock/issues/37> and <https://github.com/paulgb/BarbBlock/pull/38>.

<https://github.com/paulgb/BarbBlock/pull/38> fixes the dupe in the generated lists but does not fix the duplication in the master list (That I fixed here).
I would add the contents of <https://github.com/paulgb/BarbBlock/pull/38> here too, but I don't want to "steal the credit".